### PR TITLE
Wheel selection for player list + pagination indication/info

### DIFF
--- a/UTGame/Src/SpectatorUI/Classes/SpectatorUI_ClientSettings.uc
+++ b/UTGame/Src/SpectatorUI/Classes/SpectatorUI_ClientSettings.uc
@@ -26,6 +26,7 @@ var config name SwitchViewToButton;
 
 var config float PlayerSwitchDelay;
 var config float PostPlayerSwitchDelay;
+var config float PlayerlistRenderMode;
 
 var config string PickupNotificationPattern;
 var config string RedFlagNotificationPattern, BlueFlagNotificationPattern;
@@ -58,4 +59,5 @@ defaultproperties
     
     PlayerSwitchDelay=0.5
     PostPlayerSwitchDelay=2.0
+    PlayerlistRenderMode=0
 }


### PR DESCRIPTION
Adds a new player list render mode. Configurable in config. Default mode is the new one which acts as a wheel instead of a linear list.
# Preview
## Original

![playerlist_wheelselection_original](https://cloud.githubusercontent.com/assets/6833006/14770598/8a1fdca8-0a75-11e6-900a-c984899fec5c.gif)
## Wheel

| even | uneven |
| --- | :-: |
| ![playerlist_wheelselection_even](https://cloud.githubusercontent.com/assets/6833006/14770663/5373da0e-0a77-11e6-8a1d-918826c64c31.gif) | ![playerlist_wheelselection_uneven](https://cloud.githubusercontent.com/assets/6833006/14770616/c471107a-0a75-11e6-84e1-c6cbcfb74f03.gif) |
# Pagination

Additionally both render modes have a kind of pagination. If there are more players than the current space can draw, the list will be truncated and show how many items are left. By scrolling down it will continue displaying the remaining list.
## Original with pagination

![playerlist_wheelselection_pagination_original](https://cloud.githubusercontent.com/assets/6833006/14770679/b9c99a64-0a77-11e6-9da0-686546423efb.gif)
## Wheel with pagination

![playerlist_wheelselection_pagination_default](https://cloud.githubusercontent.com/assets/6833006/14770674/9c27e146-0a77-11e6-9e2d-4a83887d9945.gif)
