### PR TITLE
Removed unused expression

### DIFF
--- a/UTGame/Src/SpectatorUI/Classes/SpectatorUI_Interaction.uc
+++ b/UTGame/Src/SpectatorUI/Classes/SpectatorUI_Interaction.uc
@@ -941,8 +941,6 @@ function FlagEvent(UTCarriedObject Flag, name EventType, PlayerReplicationInfo W
 
     Team = Flag.GetTeamNum();
 
-    Desc = Who.GetPlayerAlias();
-
     switch (EventType) {
         case 'Taken': 
             Verb = "taken"; 


### PR DESCRIPTION
also causing error logs (accessed none)
